### PR TITLE
Add missing deps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,13 +111,18 @@ configure_file(
   configuration: cdata,
 )
 
+threads_dep = dependency('threads')
+dl_dep = cc.find_library('dl', required: false)
+
 tcc = library('tcc', sources,
   c_args: ['-DONE_SOURCE=0'],
   install: true,
+  dependencies: [threads_dep, dl_dep],
 )
 tcc_dep = declare_dependency(
   link_with: tcc,
   include_directories: include_directories('.'),
+  variables: {'libdir': get_option('libdir')},
 )
 
 pkg = import('pkgconfig')


### PR DESCRIPTION
* Adds `libdir` for compatibility with `pkgconfig` directives in `get_variable`.

Also noted by @QuLogic in GitHub comments prior.