### PR TITLE
Add basic support for iOS 26 relocation

### DIFF
--- a/libtcc.h
+++ b/libtcc.h
@@ -105,6 +105,11 @@ LIBTCCAPI int tcc_relocate(TCCState *s1, void *ptr);
    returns -1 if error. */
 #define TCC_RELOCATE_AUTO (void*)1
 
+/* lower level version of tcc_relocate without internal allocation, the
+   ptr_diff argument can be set when the writable memory in ptr is
+   a writable view displaced from the actual executable memory */
+LIBTCCAPI int tcc_relocate_ex(TCCState *s1, void *ptr, size_t ptr_diff);
+
 /* return symbol value or NULL if not found */
 LIBTCCAPI void *tcc_get_symbol(TCCState *s, const char *name);
 


### PR DESCRIPTION
Expose `tcc_relocate_ex` and tweak the logic so that `ptr_diff` can be used for MACHO targets to express a rigid offset from the writable memory passed in `ptr` to the actual executable address used for relocation.

In this way the compiled executable is copied to the writable view of the memory, `mprotect` acts on the already-executable ranges having no negative impact, and the code is retro-compatible because calling `tcc_relocate` will have `ptr_diff` set to `0` (except on selinux when internal allocation is enabled) behaving exactly as before minimizing the impact on the library size and complexity.